### PR TITLE
Adding requirements file

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ optional arguments:
 
 ## Requirements
 * Python 2.7
-* ```pip install fake-factory numpy ```
+* ```pip install -r requirements.txt```
 
 ## License
 This script is released under the [Apache version 2](LICENSE) license.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fake-factory==0.7.2
+numpy==1.11.2
+Faker==0.7.3
+pytz==2016.7


### PR DESCRIPTION
I noticed that `fake-factory` and `numpy` were not the only modules you had to pip install to run this locally.

Confirmed on my end that doing a fresh `pip install -r requirements.txt` with those requirements allows me to run the fake log generator.
