### PR TITLE
Add `--sleep` option to sleep between line generation

### DIFF
--- a/apache-fake-log-gen.py
+++ b/apache-fake-log-gen.py
@@ -40,7 +40,7 @@ parser = argparse.ArgumentParser(__file__, description="Fake Apache Log Generato
 parser.add_argument("--output", "-o", dest='output_type', help="Write to a Log file, a gzip file or to STDOUT", choices=['LOG','GZ','CONSOLE'] )
 parser.add_argument("--num", "-n", dest='num_lines', help="Number of lines to generate (0 for infinite)", type=int, default=1)
 parser.add_argument("--prefix", "-p", dest='file_prefix', help="Prefix the output file name", type=str)
-parser.add_argument("--sleep", "-s", help="Sleep this long between lines", default=0.0, type=float)
+parser.add_argument("--sleep", "-s", help="Sleep this long between lines (in seconds)", default=0.0, type=float)
 
 args = parser.parse_args()
 

--- a/apache-fake-log-gen.py
+++ b/apache-fake-log-gen.py
@@ -40,6 +40,7 @@ parser = argparse.ArgumentParser(__file__, description="Fake Apache Log Generato
 parser.add_argument("--output", "-o", dest='output_type', help="Write to a Log file, a gzip file or to STDOUT", choices=['LOG','GZ','CONSOLE'] )
 parser.add_argument("--num", "-n", dest='num_lines', help="Number of lines to generate (0 for infinite)", type=int, default=1)
 parser.add_argument("--prefix", "-p", dest='file_prefix', help="Prefix the output file name", type=str)
+parser.add_argument("--sleep", "-s", help="Sleep this long between lines", default=0.0, type=float)
 
 args = parser.parse_args()
 
@@ -75,7 +76,10 @@ ualist = [faker.firefox, faker.chrome, faker.safari, faker.internet_explorer, fa
 
 flag = True
 while (flag):
-	increment = datetime.timedelta(seconds=random.randint(30,300))
+	if args.sleep:
+		increment = datetime.timedelta(seconds=args.sleep)
+	else:
+		increment = datetime.timedelta(seconds=random.randint(30, 300))
 	otime += increment
 
 	ip = faker.ipv4()
@@ -95,3 +99,5 @@ while (flag):
 
 	log_lines = log_lines - 1
 	flag = False if log_lines == 0 else True
+	if args.sleep:
+		time.sleep(args.sleep)


### PR DESCRIPTION
The `-n 0` option is great for generating infinite logs, but I rapidly ran into the problem that it was basically creating text as fast as it possibly could.  This led to some pretty big files for the small project I was working on.  To fix this, I added a `--sleep` option that throttles the generation (as well as keeping the timestamps in step accordingly).