### PR TITLE
Updated readme and added flush after every write

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# .log and .gz files that may be generated in source directory
+*.log
+*.gz

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ Generate 100 log lines into a .log file
 $ python apache-fake-log-gen.py -n 100 -o LOG 
 ```
 
-Generate 100 log lines into a .gz file
+Generate 100 log lines into a .gz file at intervals of 10 seconds
 ```
-$ python apache-fake-log-gen.py -n 100 -o GZ 
+$ python apache-fake-log-gen.py -n 100 -o GZ -s 10
 ```
 
 Infinite log file generation (useful for testing File Tail Readers)

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Detailed help
 $ python apache-fake-log-gen.py -h
 usage: apache-fake-log-gen.py [-h] [--output {LOG,GZ,CONSOLE}]
                               [--num NUM_LINES] [--prefix FILE_PREFIX]
+                              [--sleep SLEEP]
 
 Fake Apache Log Generator
 
@@ -52,6 +53,8 @@ optional arguments:
                         Number of lines to generate (0 for infinite)
   --prefix FILE_PREFIX, -p FILE_PREFIX
                         Prefix the output file name
+  --sleep SLEEP, -s SLEEP
+                        Sleep this long between lines (in seconds)
 ```
 
 

--- a/apache-fake-log-gen.py
+++ b/apache-fake-log-gen.py
@@ -96,6 +96,7 @@ while (flag):
 	referer = faker.uri()
 	useragent = numpy.random.choice(ualist,p=[0.5,0.3,0.1,0.05,0.05] )()
 	f.write('%s - - [%s %s] "%s %s HTTP/1.0" %s %s "%s" "%s"\n' % (ip,dt,tz,vrb,uri,resp,byt,referer,useragent))
+	f.flush()
 
 	log_lines = log_lines - 1
 	flag = False if log_lines == 0 else True


### PR DESCRIPTION
In some environments (faced this in Ubuntu server LTS 16.04) the buffer is flushed after getting filled, which can lead to latency when using a tool such as tail or Logstash.