### PR TITLE
Update requirements.txt (numpy 1.14.6)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 fake-factory==0.7.2
-numpy==1.11.2
+numpy==1.14.6
 Faker==0.7.3
 pytz==2016.7
 tzlocal==1.3.0


### PR DESCRIPTION
I had to update the version of numpy to 1.14.6 to be able to build requirements on my version of python (3.7) and pip (18.0)

See https://github.com/numpy/numpy/issues/10500