### PR TITLE
Update apache-fake-log-gen.py to fix #20 on python 3.7

### DIFF
--- a/apache-fake-log-gen.py
+++ b/apache-fake-log-gen.py
@@ -25,8 +25,10 @@ class switch(object):
 
     def __iter__(self):
         """Return the match method once, then stop"""
-        yield self.match
-        raise StopIteration
+        try:
+            yield self.match
+        except StopIteration:
+            return
 
     def match(self, *args):
         """Indicate whether or not to enter a case suite"""


### PR DESCRIPTION
fix "RuntimeError: generator raised StopIteration" error on python 3.7 due to PEP 479 enforcement (https://docs.python.org/3/whatsnew/3.7.html#changes-in-python-behavior)

https://github.com/kiritbasu/Fake-Apache-Log-Generator/issues/20